### PR TITLE
Show progress when sliding

### DIFF
--- a/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
@@ -266,13 +266,15 @@ open class Debugger(private val connection: Connection, start: Boolean = true, p
             return
         }
 
-        checkpoints.removeLast() // Remove current state, we don't need to restore this, we are already in this state.
+        val currentState = checkpoints.removeLast() // Remove current state, we don't need to restore this, we are already in this state.
         val nSnapshots = checkpoints.subList(checkpoints.size - n, checkpoints.size).toList()
         for (checkpoint in nSnapshots.reversed()) {
             if (checkpoint != null && (checkpoint.snapshot.pc in binaryInfo.after_primitive_calls || nSnapshots.first() == checkpoint)) {
             //if (snapshot != null) {
                 println("Snapshot to ${checkpoint.snapshot.pc}")
-                loadSnapshot(checkpoint.snapshot)
+                val s = checkpoint.snapshot
+                s.breakpoints = currentState!!.snapshot.breakpoints
+                loadSnapshot(s)
             }
             stepDone()
         }
@@ -287,7 +289,9 @@ open class Debugger(private val connection: Connection, start: Boolean = true, p
             for (checkpoint in checkpoints.reversed()) {
                 if (checkpoint != null) {
                     println("Jumping to ${checkpoint.snapshot.pc}")
-                    loadSnapshot(checkpoint.snapshot)
+                    val s = checkpoint.snapshot
+                    s.breakpoints = currentState!!.snapshot.breakpoints
+                    loadSnapshot(s)
                     break
                 }
                 stepForward++

--- a/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
@@ -307,6 +307,9 @@ open class Debugger(private val connection: Connection, start: Boolean = true, p
     fun addBreakpoint(address: Int) {
         send(6, String.format("%08x", address))
         messageQueue.waitForResponse("BP $address!")
+
+        val s = checkpoints.last()!!.snapshot
+        s.breakpoints = s.breakpoints!!.toMutableList() + address
     }
     fun removeBreakpoint(address: Int) {
         send(7, String.format("%08x", address))

--- a/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
@@ -318,6 +318,9 @@ open class Debugger(private val connection: Connection, start: Boolean = true, p
     fun removeBreakpoint(address: Int) {
         send(7, String.format("%08x", address))
         messageQueue.waitForResponse("BP $address!")
+
+        val s = checkpoints.last()!!.snapshot
+        s.breakpoints = s.breakpoints!!.toMutableList() - address
     }
     private fun internalContinueFor(n: Int) {
         //Thread.sleep(n * 1L)

--- a/src/main/kotlin/be/ugent/topl/mio/debugger/MultiverseDebugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/debugger/MultiverseDebugger.kt
@@ -214,13 +214,13 @@ class MultiverseDebugger(
     }
 
     override fun continueFor(n: Int) {
-        var destinationNode = graph.currentNode
+        /*var destinationNode = graph.currentNode
         for (i in 0 ..< n) {
             destinationNode = destinationNode.nextNode(overrides)
-        }
+        }*/
         super.continueFor(n)
 
-        graph.currentNode = destinationNode
+        //graph.currentNode = destinationNode
         graphUpdated()
     }
 

--- a/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
@@ -499,6 +499,12 @@ class MultiversePanel(private val multiverseDebugger: MultiverseDebugger, graph:
             followButton.isEnabled = false
             customButton.isEnabled = false
             thread {
+                // Disable breakpoints
+                val breakpointsStart = multiverseDebugger.checkpoints.last()!!.snapshot.breakpoints!!
+                for (breakpoint in breakpointsStart) {
+                    multiverseDebugger.removeBreakpoint(breakpoint)
+                }
+
                 multiverseDebugger.printCheckpoints(multiverseDebugger.wasmBinary.metadata)
 
                 val backwardsLength = graphPanel.selectedPath!!.first.size
@@ -541,7 +547,10 @@ class MultiversePanel(private val multiverseDebugger: MultiverseDebugger, graph:
                     }
                 }
                 graphPanel.repaint()
-                //Thread.sleep(1000)
+                // Re-enable breakpoints
+                for (breakpoint in breakpointsStart) {
+                    multiverseDebugger.addBreakpoint(breakpoint)
+                }
                 stateChanged(multiverseDebugger.checkpoints.last(), 1.0)
                 //debugger.continueFor(forwardPath.size - 1)
 

--- a/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
@@ -505,11 +505,12 @@ class MultiversePanel(private val multiverseDebugger: MultiverseDebugger, graph:
                 val forwardsLength = graphPanel.selectedPath!!.second.size
                 val totalLength = backwardsLength + forwardsLength
                 val backwardPath = graphPanel.selectedPath!!.first.toMutableList()
+                var finishedSteps = 0
                 multiverseDebugger.stepBack(backwardPath.size, multiverseDebugger.wasmBinary.metadata) {
                     graphPanel.completedPath.add(backwardPath.removeFirst())
                     graphPanel.repaint()
                     val remaining = forwardsLength + backwardPath.size
-                    val finishedSteps = totalLength - remaining
+                    finishedSteps = totalLength - remaining
                     stateChanged(multiverseDebugger.checkpoints.last(), finishedSteps / totalLength.toDouble())
                 }
 
@@ -530,6 +531,10 @@ class MultiversePanel(private val multiverseDebugger: MultiverseDebugger, graph:
                 }
                 for (action in actionPath) {
                     action.doAction()
+                    if (action is ContinueForAction) {
+                        finishedSteps += action.n
+                        stateChanged(multiverseDebugger.checkpoints.last(), finishedSteps / totalLength.toDouble())
+                    }
                 }
                 graphPanel.completedPath.addAll(forwardPath.subList(0, forwardPath.size - 1))
                 graphPanel.repaint()

--- a/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
@@ -106,12 +106,6 @@ class InteractiveDebugger(
     private var currentFileName = sourceMapping?.getSourceFile(0)
 
     init {
-        debugger.startReading()
-        debugger.pause()
-        debugger.setSnapshotPolicy(Debugger.SnapshotPolicy.Checkpointing())
-    }
-
-    init {
         FlatSVGIcon.ColorFilter.getInstance()
             .add( Color.black, debugBlue, debugBlue)
         updateEnabledButtons()
@@ -335,6 +329,20 @@ class InteractiveDebugger(
         })
         defaultCloseOperation = EXIT_ON_CLOSE
         isVisible = true
+    }
+
+    init {
+        debugger.startReading()
+        debugger.setSnapshotPolicy(Debugger.SnapshotPolicy.Checkpointing())
+        pause()
+    }
+
+    private fun pause() {
+        debugger.pause()
+        pauseButton.icon = FlatSVGIcon(continueIcon)
+        paused = !paused
+        updateEnabledButtons()
+        updatePcLabel()
     }
 
     private fun updateEnabledButtons() {

--- a/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
@@ -514,7 +514,7 @@ class MultiversePanel(private val multiverseDebugger: MultiverseDebugger, graph:
                     stateChanged(multiverseDebugger.checkpoints.last(), finishedSteps / totalLength.toDouble())
                 }
 
-                val forwardPath = graphPanel.selectedPath!!.second
+                val forwardPath = graphPanel.selectedPath!!.second.toMutableList()
                 val actionPath = mutableListOf<MultiverseAction>()
                 for (i in 1..<forwardPath.size) {
                     val a = forwardPath[i - 1]
@@ -534,9 +534,12 @@ class MultiversePanel(private val multiverseDebugger: MultiverseDebugger, graph:
                     if (action is ContinueForAction) {
                         finishedSteps += action.n
                         stateChanged(multiverseDebugger.checkpoints.last(), finishedSteps / totalLength.toDouble())
+                        repeat(action.n) {
+                            graphPanel.completedPath.add(forwardPath.removeFirst())
+                        }
+                        graphPanel.repaint()
                     }
                 }
-                graphPanel.completedPath.addAll(forwardPath.subList(0, forwardPath.size - 1))
                 graphPanel.repaint()
                 //Thread.sleep(1000)
                 stateChanged(multiverseDebugger.checkpoints.last(), 1.0)

--- a/src/main/kotlin/be/ugent/topl/mio/ui/StartScreen.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/ui/StartScreen.kt
@@ -75,7 +75,7 @@ open class StartScreen(config: DebuggerConfig) : AboutScreen(config) {
 
     private fun startDebugger(binary: File, emulator: Boolean, comPort: String?): Boolean {
         val connection = if (emulator) {
-            ProcessConnection(config.wdcliPath, binary.path, "--no-socket")
+            ProcessConnection(config.wdcliPath, binary.path, "--no-socket", "--paused")
         }
         else {
             if (comPort == null) {

--- a/src/main/kotlin/be/ugent/topl/mio/woodstate/WOODState.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/woodstate/WOODState.kt
@@ -139,7 +139,7 @@ data class WOODDumpResponse(
     val pc: Int?,
     val pc_error: Int?,
     val exception_msg: String?,
-    val breakpoints: List<Int>?,
+    var breakpoints: List<Int>?,
     val stack: List<WasmStackValue>?,
     val callstack: List<Frame>?,
     val globals: List<WasmStackValue>?,
@@ -198,7 +198,8 @@ class WOODState(woodResponse: WOODDumpResponse) {
         // |      Header       |        Breakpoints
         // | BPState  | Nr BPS |     BP1          | BP2 | ...
         // |  2 bytes |   1*2  | serializePointer |
-        if (this.woodResponse.breakpoints == null) {
+        val bps = this.woodResponse.breakpoints
+        if (bps == null) {
             return
         }
         println("==============")
@@ -207,7 +208,7 @@ class WOODState(woodResponse: WOODDumpResponse) {
         val ws = this
         val nrBytesUsedForAmountBPs = 1 * 2
         val headerSize = ExecutionStateType.breakpointState.hexStr.length + nrBytesUsedForAmountBPs
-        var breakpoints = this.woodResponse.breakpoints.map{ bp -> ws.serializePointer(bp) }
+        var breakpoints = bps.map{ bp -> ws.serializePointer(bp) }
         while (breakpoints.size != 0) {
             val fits = stateMsgs.howManyFit(headerSize, breakpoints)
             if (fits == 0) {


### PR DESCRIPTION
This PR adds a progress bar that shows the current progress for a slide operation. This is useful for very large slide operations that take a longer amount of time.

This PR also adds some other fixes to slide to work better with breakpoints.

Bugs fixed:
- [x] Slide over breakpoints freezes the debugger.
- [x] Breakpoints disappear after stepping back.
- [x] Step back with re-execute over a breakpoint freezes the debugger.

https://github.com/user-attachments/assets/751ca9a8-d284-4407-9595-e13b2816857e

In future work, we should add a test to test step back not breaking on breakpoints:
```ts
@external("env", "chip_delay") declare function chip_delay(value: i32): void;

export function main(): void {
    while (true) {
        let x = 0;
        for (let i = 0; i < 30; i++) {
            x += 1;
        }
        chip_delay(10);
    }
}
```
Reproduce: Place breakpoint on chip_delay(10), continue. Place breakpoint on `x += 1` and press step back until it freezes.