### PR TITLE
Fix jump button being enabled the moment the debugger is paused

### DIFF
--- a/src/main/kotlin/be/ugent/topl/mio/ui/GraphPanel.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/ui/GraphPanel.kt
@@ -40,7 +40,8 @@ class GraphPanel(private val graph: MultiverseGraph) : JPanel(),
     private var renderedHeight = 500
     private var renderedWidth = 2000
     private val nodes = mutableListOf<Node>()
-    private var selectedNode: Node? = null
+    var selectedNode: Node? = null
+        private set
 
     // Panning
     private var startPos = Point(0, 0)

--- a/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
@@ -749,7 +749,7 @@ class MultiversePanel(private val multiverseDebugger: MultiverseDebugger, config
         concolicButton.isEnabled = enabled
         //customButton.isEnabled = enabled && multiverseDebugger.graph.currentNode is PrimitiveNode
         customButton.isEnabled = enabled
-        followButton.isEnabled = enabled
+        followButton.isEnabled = enabled && graphPanel.selectedNode != null
     }
 }
 


### PR DESCRIPTION
It should still check if a node is actually selected or not.