### PR TITLE
Add GDBStub for debugging with LLDB

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -29,6 +29,9 @@ dependencies {
     // Needed for AssemblyScript source mapping:
     //implementation("com.atlassian.sourcemap:sourcemap:2.0.0")
     implementation("com.google.code.gson:gson:2.11.0")
+
+    // Logging
+    implementation("ch.qos.logback:logback-classic:1.5.32")
 }
 
 tasks.test {

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -11,7 +11,6 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.Arrays;
 
 import static be.ugent.topl.mio.sourcemap.DwarfSourceMapKt.getDwarfSourcemap;
 
@@ -81,36 +80,6 @@ public class GdbStub {
         return addr & Long.MAX_VALUE;
     }
 
-    record CodeSection(byte[] data, int offset) {}
-
-    private CodeSection getCodeSection(String filename) throws IOException {
-        byte[] wasmBytes = Files.readAllBytes(Path.of(filename));
-        int i = 8; // skip header
-
-        while (i < wasmBytes.length) {
-            int sectionId = wasmBytes[i++] & 0xFF;
-
-            // LEB128 section size
-            int size = 0;
-            int shift = 0;
-            int b;
-            do {
-                b = wasmBytes[i++] & 0xFF;
-                size |= (b & 0x7F) << shift;
-                shift += 7;
-            } while ((b & 0x80) != 0);
-
-            if (sectionId == 10) { // code section
-                System.out.println("Found code section at address " + i);
-                //return new CodeSection(Arrays.copyOfRange(wasmBytes, i, i + size), i);
-                return new CodeSection(wasmBytes, i);
-            }
-
-            i += size;
-        }
-        return null;
-    }
-
     private String getTriple(String s) {
         String hex = s.chars()
                 .mapToObj(c -> String.format("%02x", c))
@@ -125,11 +94,9 @@ public class GdbStub {
     }
 
     public void start() throws IOException {
-        //System.out.println(stripAddrType(0x800000000000fffcL)); // 65532
         debugger.pause();
 
-        System.out.println(toHex(4508));
-        CodeSection codeSection = getCodeSection(binaryLocation);
+        byte[] wasmData = Files.readAllBytes(Path.of(binaryLocation));
 
         for (int i = 0; i < regs.length; i++) {
             regs[i] = 0x11111111 * (i + 1);
@@ -167,7 +134,7 @@ public class GdbStub {
                     continue;
                 }*/
 
-                byte[] memory = codeSection.data;
+                byte[] memory = wasmData;
                 if (addrType == 1) {
                     log("Reading from wasm linear memory");
                     memory = getCurrentState().getMemory().getBytes();
@@ -215,11 +182,7 @@ public class GdbStub {
                 // +--------------------+--------------------+
                 //  <----- 32 bit -----> <----- 32 bit ----->
                 // Offset 0, module id 0
-                // toHex(codeSection.offset, 4)
-                //"0x00044444"
-                //sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"0x" + toHex(codeSection.offset, 4, false) + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
-                sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"" + codeSection.offset + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
-                //sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"" + "0x00000000" + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
+                sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"0x00000000\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
                 continue;
             }
             // TODO: We can probably remove this:

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -153,6 +153,13 @@ public class GdbStub {
                 long len = Long.parseUnsignedLong(memArgs[1], 16);
                 log("Read memory " + len + " bytes from " + pos + " with addr type = " + addrType);
 
+                // TODO: Hack to temporarily prevent lldb from using breakpoints when stepping
+                //  https://github.com/llvm/llvm-project/issues/189960
+                if (addrType == 0) {
+                    sendPacket(out, "E01");
+                    continue;
+                }
+
                 byte[] memory = rawCodeSection;
                 if (addrType == 1) {
                     log("Reading from wasm linear memory");
@@ -160,7 +167,7 @@ public class GdbStub {
                 }
 
                 // The reply may contain fewer addressable memory units than requested if the server was reading from a trace frame memory and was able to read only part of the region of memory.
-                if (pos + len >= memory.length) {
+                if (pos >= memory.length) {
                     System.out.println("Out of bounds for length " + memory.length);
                     sendPacket(out, "E01");
                     continue;
@@ -171,10 +178,10 @@ public class GdbStub {
                     // TODO: read from pos + i
                     // also think about little vs big endian
                     int index = (int) pos + i;
-                    /*if (index >= memory.length) {
+                    if (index >= memory.length) {
                         System.out.println("Stop reading, out of bounds");
                         break;
-                    }*/
+                    }
                     int b = memory[index];
                     result.append(String.format("%02x", b & 0xFF));
                     //result.append("00");
@@ -264,9 +271,9 @@ public class GdbStub {
             }
 
             switch (pkt) {
-                case "QStartNoAckMode":
+                /*case "QStartNoAckMode":
                     sendPacket(out, "OK");
-                    break;
+                    break;*/
                 case "qHostInfo":
                     //sendPacket(out, "triple:x86_64-pc-linux-gnu;endian:little;ptrsize:8;");
                     //sendPacket(out, "cputype:16777228;cpusubtype:3;ostype:darwin;vendor:apple;endian:little;ptrsize:8;hostname:hello;");

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -52,17 +52,20 @@ public class GdbStub {
         return sb.toString();
     }
 
-    private String toHex(long data, int maxLen) {
+    private String toHex(long data, int maxLen, boolean bigEndian) {
         StringBuilder result = new StringBuilder();
         for (int i = 0; i < maxLen; i++) {
             long b = (data >> i * 8) & 0xff;
+            if (!bigEndian) {
+                b = (data >> (maxLen - i - 1) * 8) & 0xff;
+            }
             result.append(String.format("%02x", b));
         }
         return result.toString();
     }
 
     private String toHex(long data) {
-        return toHex(data, 8);
+        return toHex(data, 8, true);
     }
 
     private long toWasmAddr(long addr) {
@@ -78,7 +81,9 @@ public class GdbStub {
         return addr & Long.MAX_VALUE;
     }
 
-    private byte[] getCodeSection(String filename) throws IOException {
+    record CodeSection(byte[] data, int offset) {}
+
+    private CodeSection getCodeSection(String filename) throws IOException {
         byte[] wasmBytes = Files.readAllBytes(Path.of(filename));
         int i = 8; // skip header
 
@@ -96,7 +101,8 @@ public class GdbStub {
             } while ((b & 0x80) != 0);
 
             if (sectionId == 10) { // code section
-                return Arrays.copyOfRange(wasmBytes, i, i + size);
+                System.out.println("Found code section at address " + i);
+                return new CodeSection(Arrays.copyOfRange(wasmBytes, i, i + size), i);
             }
 
             i += size;
@@ -122,7 +128,7 @@ public class GdbStub {
         debugger.pause();
 
         System.out.println(toHex(4508));
-        byte[] rawCodeSection = getCodeSection(binaryLocation);
+        CodeSection codeSection = getCodeSection(binaryLocation);
 
         for (int i = 0; i < regs.length; i++) {
             regs[i] = 0x11111111 * (i + 1);
@@ -160,7 +166,7 @@ public class GdbStub {
                     continue;
                 }
 
-                byte[] memory = rawCodeSection;
+                byte[] memory = codeSection.data;
                 if (addrType == 1) {
                     log("Reading from wasm linear memory");
                     memory = getCurrentState().getMemory().getBytes();
@@ -205,7 +211,10 @@ public class GdbStub {
                 // +--------------------+--------------------+
                 //  <----- 32 bit -----> <----- 32 bit ----->
                 // Offset 0, module id 0
-                sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"0x00000000\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
+                // toHex(codeSection.offset, 4)
+                //"0x00044444"
+                //sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"0x" + toHex(codeSection.offset, 4, false) + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
+                sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"" + "0x00000000" + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
                 continue;
             }
             // TODO: We can probably remove this:
@@ -292,6 +301,7 @@ public class GdbStub {
                 case "qWasmCallStack:1": // Get the callstack for thread 1.
                     Checkpoint lastCheckpoint = debugger.getCheckpoints().getLast();
                     WOODDumpResponse state = getCurrentState();
+                    //long currentPc = (long) state.getPc() - codeSection.offset;
                     long currentPc = (long) state.getPc();
                     String result = toHex(currentPc);
                     for (int i = 0; i < state.getCallstack().size() - 1; i++) {

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -1,7 +1,6 @@
 package be.ugent.topl.mio;
 
 import be.ugent.topl.mio.debugger.Debugger;
-import be.ugent.topl.mio.sourcemap.SourceMap;
 import be.ugent.topl.mio.woodstate.Frame;
 import be.ugent.topl.mio.woodstate.WOODDumpResponse;
 import org.slf4j.Logger;
@@ -15,20 +14,16 @@ import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
 
-import static be.ugent.topl.mio.sourcemap.DwarfSourceMapKt.getDwarfSourcemap;
-
 public class GdbStub {
     private final Debugger debugger;
     private final String binaryLocation;
     private OutputStream out;
     private final Logger logger = LoggerFactory.getLogger(GdbStub.class);
     private boolean stepForward = true;
-    private final SourceMap debugSourceMap; // Remove later, lldb doesn't need this.
 
     public GdbStub(Debugger debugger, String binaryLocation) {
         this.debugger = debugger;
         this.binaryLocation = binaryLocation;
-        this.debugSourceMap = getDwarfSourcemap(binaryLocation);
 
         debugger.getBreakpointsListeners().add((pc) -> {
             try {
@@ -225,10 +220,6 @@ public class GdbStub {
                 logger.info("Add breakpoint on {}", addr);
                 debugger.addBreakpoint((int) addr);
 
-                try {
-                    logger.info("Add breakpoint at {}:{}", debugSourceMap.getSourceFileName((int) addr), debugSourceMap.getLineForPc((int) addr));
-                } catch(Exception _) {}
-
                 // A remote target shall return an empty string for an unrecognized breakpoint or watchpoint packet type.
                 sendPacket(out, "OK");
                 continue;
@@ -241,10 +232,6 @@ public class GdbStub {
                 int kind = Integer.parseInt(args[2]);
                 logger.info("Remove breakpoint on {}", addr);
                 debugger.removeBreakpoint((int) addr);
-
-                try {
-                    logger.info("Remove breakpoint at {}:{}", debugSourceMap.getSourceFileName((int) addr), debugSourceMap.getLineForPc((int) addr));
-                } catch(Exception _) {}
 
                 // A remote target shall return an empty string for an unrecognized breakpoint or watchpoint packet type.
                 sendPacket(out, "OK");
@@ -298,10 +285,6 @@ public class GdbStub {
                         }
                     }
                     sendPacket(out, result);
-
-                    try {
-                        logger.info("At {}:{}", debugSourceMap.getSourceFileName(state.getPc()), debugSourceMap.getLineForPc(state.getPc()));
-                    } catch(Exception _) {}
 
                     break;
                 case "qC": // Get thread id

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -22,6 +22,7 @@ public class GdbStub {
     private final String binaryLocation;
     private OutputStream out;
     private final Logger logger = LoggerFactory.getLogger(GdbStub.class);
+    private boolean stepForward = true;
     private final SourceMap debugSourceMap; // Remove later, lldb doesn't need this.
 
     public GdbStub(Debugger debugger, String binaryLocation) {
@@ -164,6 +165,7 @@ public class GdbStub {
                 continue;
             }
             else if (pkt.startsWith("qSupported")) {
+                //ReverseContinue+;
                 sendPacket(out, "qXfer:libraries:read+;vContSupported-;wasm+;ReverseStep+;");
                 continue;
             }
@@ -243,6 +245,20 @@ public class GdbStub {
                 //debugger.stepBack(1, wasmData);
                 sendPacket(out, getCurrentState().getStack().toString());
                 continue;
+            } else if (pkt.startsWith("bs")) {
+                if (pkt.equals("bs")) {
+                    stepBack(1);
+                } else {
+                    int n = Integer.parseInt(pkt.split(" ")[1]);
+                    logger.info("Step back {} instruction(s)", n);
+                    stepBack(n);
+                }
+                continue;
+            } else if (pkt.startsWith("QSetStepDir:")) {
+                stepForward = Integer.parseInt(pkt.substring("QSetStepDir:".length())) == 0;
+                logger.info("Change step direction to {}", stepForward ? "forward" : "backward");
+                sendPacket(out, "OK");
+                continue;
             }
 
             switch (pkt) {
@@ -296,12 +312,15 @@ public class GdbStub {
                     break;
                 case "s":
                     logger.info("Received step command from lldb");
-                    debugger.stepInto();
-                    sendStopPacket(out, "05");
-                    break;
-                case "bs":
-                    debugger.stepBack(1, () -> null);
-                    sendStopPacket(out, "05");
+                    if (stepForward) {
+                        logger.info("Step forward");
+                        debugger.stepInto();
+                        sendStopPacket(out, "05");
+                    }
+                    else {
+                        logger.info("Step backward");
+                        stepBack(1);
+                    }
                     break;
                 case "c":
                     logger.info("Continue execution");
@@ -323,6 +342,16 @@ public class GdbStub {
                     break;
             }
         }
+    }
+
+    private void stepBack(int n) throws IOException {
+        if (!debugger.canStepBack(n)) {
+            sendPacket(out, "E01");
+            return;
+        }
+
+        debugger.stepBack(n, () -> null);
+        sendStopPacket(out, "05");
     }
 
     private void sendStopPacket(OutputStream out, String signal) throws IOException {

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -33,7 +33,7 @@ public class GdbStub {
         debugger.getBreakpointsListeners().add((pc) -> {
             try {
                 logger.info("Stopped at breakpoint {}", pc);
-                sendPacket(out, "S05");
+                sendStopPacket(out, "05");
             } catch (IOException e) {
                 throw new RuntimeException(e);
             }

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -102,7 +102,8 @@ public class GdbStub {
 
             if (sectionId == 10) { // code section
                 System.out.println("Found code section at address " + i);
-                return new CodeSection(Arrays.copyOfRange(wasmBytes, i, i + size), i);
+                //return new CodeSection(Arrays.copyOfRange(wasmBytes, i, i + size), i);
+                return new CodeSection(wasmBytes, i);
             }
 
             i += size;
@@ -161,20 +162,23 @@ public class GdbStub {
 
                 // TODO: Hack to temporarily prevent lldb from using breakpoints when stepping
                 //  https://github.com/llvm/llvm-project/issues/189960
-                if (addrType == 0) {
+                /*if (addrType == 0) {
                     sendPacket(out, "E01");
                     continue;
-                }
+                }*/
 
                 byte[] memory = codeSection.data;
                 if (addrType == 1) {
                     log("Reading from wasm linear memory");
                     memory = getCurrentState().getMemory().getBytes();
                 }
+                else {
+                    //pos -= codeSection.offset;
+                }
 
                 // The reply may contain fewer addressable memory units than requested if the server was reading from a trace frame memory and was able to read only part of the region of memory.
-                if (pos >= memory.length) {
-                    System.out.println("Out of bounds for length " + memory.length);
+                if (pos >= memory.length || pos < 0) {
+                    System.out.println("Pos " + pos + " out of bounds for length " + memory.length);
                     sendPacket(out, "E01");
                     continue;
                 }
@@ -214,7 +218,8 @@ public class GdbStub {
                 // toHex(codeSection.offset, 4)
                 //"0x00044444"
                 //sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"0x" + toHex(codeSection.offset, 4, false) + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
-                sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"" + "0x00000000" + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
+                sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"" + codeSection.offset + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
+                //sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"" + "0x00000000" + "\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
                 continue;
             }
             // TODO: We can probably remove this:

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -346,7 +346,7 @@ public class GdbStub {
 
     private void stepBack(int n) throws IOException {
         if (!debugger.canStepBack(n)) {
-            sendPacket(out, "E01");
+            sendPacket(out, "T" + "05" + "thread:1;name:warduino;thread-pcs:" + toHex(getCurrentState().getPc()) + ";00:" + toHex(getCurrentState().getPc()) + ";replaylog:begin;");
             return;
         }
 

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -267,15 +267,15 @@ public class GdbStub {
                     sendPacket(out, "PacketSize=4000");
                     break;
                 case "qWasmCallStack:1": // Get the callstack for thread 1.
-                    Checkpoint lastCheckpoint = debugger.getCheckpoints().getLast();
                     WOODDumpResponse state = getCurrentState();
-                    //long currentPc = (long) state.getPc() - codeSection.offset;
-                    long currentPc = (long) state.getPc();
-                    String result = toHex(currentPc);
-                    for (int i = 0; i < state.getCallstack().size() - 1; i++) {
-                        result += toHex(0xdead); // TODO: Add other pc's in the callstack
+                    String result = toHex(state.getPc());
+                    for (int i = state.getCallstack().size() - 1; i >= 0; i--) {
+                        // Only functions are real callstack elements:
+                        Frame f = state.getCallstack().get(i);
+                        if (f.getType() == 0) {
+                            result += toHex(f.getRa());
+                        }
                     }
-                    log("Callstack size: " + state.getCallstack().size() + " pc = " + currentPc);
                     sendPacket(out, result);
 
                     try {

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -2,7 +2,6 @@ package be.ugent.topl.mio;
 
 import be.ugent.topl.mio.debugger.Debugger;
 import be.ugent.topl.mio.sourcemap.SourceMap;
-import be.ugent.topl.mio.woodstate.Checkpoint;
 import be.ugent.topl.mio.woodstate.Frame;
 import be.ugent.topl.mio.woodstate.WOODDumpResponse;
 
@@ -34,9 +33,6 @@ public class GdbStub {
             return null;
         });
     }
-
-    // Dummy register file (16 x 32-bit)
-    static int[] regs = new int[16];
 
     private static final char[] HEX = "0123456789abcdef".toCharArray();
     private String toHex(byte[] data, int offset, int length) {
@@ -97,10 +93,6 @@ public class GdbStub {
         debugger.pause();
 
         byte[] wasmData = Files.readAllBytes(Path.of(binaryLocation));
-
-        for (int i = 0; i < regs.length; i++) {
-            regs[i] = 0x11111111 * (i + 1);
-        }
 
         ServerSocket server = new ServerSocket(1234);
         System.out.println("Waiting for GDB on port 1234...");
@@ -395,9 +387,7 @@ public class GdbStub {
 
     private String encodeRegs() {
         StringBuilder sb = new StringBuilder();
-        for (int r : regs) {
-            sb.append(String.format("%08x", r));
-        }
+        sb.append(String.format("%08x", getCurrentState().getPc()));
         return sb.toString();
     }
 }

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -91,13 +91,13 @@ public class GdbStub {
         return debugger.getCheckpoints().getLast().getSnapshot();
     }
 
-    public void start() throws IOException {
+    public void start(int port) throws IOException {
         debugger.pause();
 
         byte[] wasmData = Files.readAllBytes(Path.of(binaryLocation));
 
-        ServerSocket server = new ServerSocket(1234);
-        System.out.println("Waiting for GDB on port 1234...");
+        ServerSocket server = new ServerSocket(port);
+        System.out.printf("Waiting for GDB on port %d...", port);
         Socket sock = server.accept();
         System.out.println("GDB connected!");
 

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -326,6 +326,10 @@ public class GdbStub {
                     logger.info("Continue execution");
                     debugger.run();
                     break;
+                /*case "bc":
+                    // TODO: Actual backwards continue in MIO
+                    stepBack(1);
+                    break;*/
                 case "pause":
                     debugger.pause();
                     sendStopPacket(out, "02");

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -1,0 +1,406 @@
+package be.ugent.topl.mio;
+
+import be.ugent.topl.mio.debugger.Debugger;
+import be.ugent.topl.mio.sourcemap.SourceMap;
+import be.ugent.topl.mio.woodstate.Checkpoint;
+import be.ugent.topl.mio.woodstate.Frame;
+import be.ugent.topl.mio.woodstate.WOODDumpResponse;
+
+import java.io.*;
+import java.net.ServerSocket;
+import java.net.Socket;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.Arrays;
+
+import static be.ugent.topl.mio.sourcemap.DwarfSourceMapKt.getDwarfSourcemap;
+
+public class GdbStub {
+    private final Debugger debugger;
+    private final String binaryLocation;
+    private OutputStream out;
+    private final SourceMap debugSourceMap; // Remove later, lldb doesn't need this.
+
+    public GdbStub(Debugger debugger, String binaryLocation) {
+        this.debugger = debugger;
+        this.binaryLocation = binaryLocation;
+        debugSourceMap = getDwarfSourcemap(binaryLocation);
+
+        debugger.getBreakpointsListeners().add((pc) -> {
+            try {
+                sendPacket(out, "S05");
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+            return null;
+        });
+    }
+
+    // Dummy register file (16 x 32-bit)
+    static int[] regs = new int[16];
+
+    private static final char[] HEX = "0123456789abcdef".toCharArray();
+    private String toHex(byte[] data, int offset, int length) {
+        StringBuilder sb = new StringBuilder(length * 2);
+
+        for (int i = 0; i < length; i++) {
+            int b = data[offset + i] & 0xFF;
+            sb.append(HEX[b >>> 4]);
+            sb.append(HEX[b & 0x0F]);
+        }
+
+        return sb.toString();
+    }
+
+    private String toHex(long data, int maxLen) {
+        StringBuilder result = new StringBuilder();
+        for (int i = 0; i < maxLen; i++) {
+            long b = (data >> i * 8) & 0xff;
+            result.append(String.format("%02x", b));
+        }
+        return result.toString();
+    }
+
+    private String toHex(long data) {
+        return toHex(data, 8);
+    }
+
+    private long toWasmAddr(long addr) {
+        // We use the upper bits of the address to indicate the type, being part of the object (0) or part of the wasm memory (1).
+        return addr | 0x1L << 63;
+    }
+
+    private long getAddrType(long addr) {
+        return addr >>> 63;
+    }
+
+    private long stripAddrType(long addr) {
+        return addr & Long.MAX_VALUE;
+    }
+
+    private byte[] getCodeSection(String filename) throws IOException {
+        byte[] wasmBytes = Files.readAllBytes(Path.of(filename));
+        int i = 8; // skip header
+
+        while (i < wasmBytes.length) {
+            int sectionId = wasmBytes[i++] & 0xFF;
+
+            // LEB128 section size
+            int size = 0;
+            int shift = 0;
+            int b;
+            do {
+                b = wasmBytes[i++] & 0xFF;
+                size |= (b & 0x7F) << shift;
+                shift += 7;
+            } while ((b & 0x80) != 0);
+
+            if (sectionId == 10) { // code section
+                return Arrays.copyOfRange(wasmBytes, i, i + size);
+            }
+
+            i += size;
+        }
+        return null;
+    }
+
+    private String getTriple(String s) {
+        String hex = s.chars()
+                .mapToObj(c -> String.format("%02x", c))
+                .reduce("", String::concat);
+
+        System.out.println(hex);
+        return hex;
+    }
+
+    public WOODDumpResponse getCurrentState() {
+        return debugger.getCheckpoints().getLast().getSnapshot();
+    }
+
+    public void start() throws IOException {
+        //System.out.println(stripAddrType(0x800000000000fffcL)); // 65532
+        debugger.pause();
+
+        System.out.println(toHex(4508));
+        byte[] rawCodeSection = getCodeSection(binaryLocation);
+
+        for (int i = 0; i < regs.length; i++) {
+            regs[i] = 0x11111111 * (i + 1);
+        }
+
+        ServerSocket server = new ServerSocket(1234);
+        System.out.println("Waiting for GDB on port 1234...");
+        Socket sock = server.accept();
+        System.out.println("GDB connected!");
+
+        InputStream in = sock.getInputStream();
+        out = sock.getOutputStream();
+
+        while (true) {
+            String pkt = recvPacket(in, out);
+            if (pkt == null) {
+                System.out.println("GDB closed");
+                break;
+            }
+            System.out.println("<- " + pkt);
+
+            if (pkt.startsWith("m")) {
+                pkt = pkt.substring(1);
+                String[] memArgs = pkt.split(",");
+                long pos = Long.parseUnsignedLong(memArgs[0], 16);
+                long addrType = getAddrType(pos);
+                pos = stripAddrType(pos);
+                long len = Long.parseUnsignedLong(memArgs[1], 16);
+                log("Read memory " + len + " bytes from " + pos + " with addr type = " + addrType);
+
+                byte[] memory = rawCodeSection;
+                if (addrType == 1) {
+                    log("Reading from wasm linear memory");
+                    memory = getCurrentState().getMemory().getBytes();
+                }
+
+                // The reply may contain fewer addressable memory units than requested if the server was reading from a trace frame memory and was able to read only part of the region of memory.
+                if (pos + len >= memory.length) {
+                    System.out.println("Out of bounds for length " + memory.length);
+                    sendPacket(out, "E01");
+                    continue;
+                }
+
+                StringBuilder result = new StringBuilder();
+                for (int i = 0; i < len; i++) {
+                    // TODO: read from pos + i
+                    // also think about little vs big endian
+                    int index = (int) pos + i;
+                    /*if (index >= memory.length) {
+                        System.out.println("Stop reading, out of bounds");
+                        break;
+                    }*/
+                    int b = memory[index];
+                    result.append(String.format("%02x", b & 0xFF));
+                    //result.append("00");
+                }
+                sendPacket(out, result.toString());
+
+                // If memory invalid send E01
+                //sendPacket(out, "E01");
+                continue;
+            }
+            else if (pkt.startsWith("qSupported")) {
+                sendPacket(out, "qXfer:libraries:read+;vContSupported-;wasm+;");
+                continue;
+            }
+            else if (pkt.startsWith("qXfer:libraries:read")) {
+                // https://github.com/v8/v8/blob/main/src/debug/wasm/gdb-server/gdb-remote-util.h#L51
+                // For LLDB debugging, an address in a Wasm module code space is represented
+                // with 64 bits, where the first 32 bits identify the module id:
+                // +--------------------+--------------------+
+                // |     module_id      |       offset       |
+                // +--------------------+--------------------+
+                //  <----- 32 bit -----> <----- 32 bit ----->
+                // Offset 0, module id 0
+                sendPacket(out, String.format("l<library-list><library name=\"%s\"><section address=\"0x00000000\"/></library></library-list>", new File(binaryLocation).getAbsolutePath()));
+                continue;
+            }
+            // TODO: We can probably remove this:
+            else if (pkt.startsWith("Hc")) {
+                sendPacket(out, "OK");
+                continue;
+            }
+            else if (pkt.startsWith("qWasmLocal:")) {
+                String[] args = pkt.substring("qWasmLocal:".length()).split(";");
+                int frameIdx =  Integer.parseInt(args[0]);
+                int localIdx =  Integer.parseInt(args[1]);
+                log("Reading local " + localIdx + " from frame " + frameIdx);
+                Frame frame = getCurrentState().getCallstack().get(getCurrentState().getCallstack().size() - frameIdx - 1);
+                System.out.println(frame);
+                System.out.println(getCurrentState().getStack());
+                int fp = frame.getFp();
+                long value = getCurrentState().getStack().get(fp + localIdx).getValue();
+                sendPacket(out, toHex(toWasmAddr(value))); // If a pointer on the stack is an address it will be clear it's a wasm memory pointer.
+                continue;
+            }
+            else if (pkt.startsWith("qRegisterInfo0")) {
+                sendPacket(out, "name:pc;alt-name:pc;bitsize:64;offset:0;encoding:uint;format:hex;set:General Purpose Registers;gcc:16;dwarf:16;generic:pc;");
+                continue;
+            }
+            else if (pkt.startsWith("p0")) {
+                sendPacket(out, toHex(getCurrentState().getPc()));
+                continue;
+            }
+            else if (pkt.startsWith("Z")) {
+                String[] args = pkt.substring(1).split(",");
+                int type = Integer.parseInt(args[0]);
+                long addr = Long.parseUnsignedLong(args[1], 16);
+                int kind = Integer.parseInt(args[2]);
+                log("Add breakpoint on " + addr);
+                debugger.addBreakpoint((int) addr);
+
+                try {
+                    for (int i = 0; i < 8; i++) {
+                        log("Breakpoint line " + debugSourceMap.getLineForPc((int) addr + (i-4) * 4) + " " + debugSourceMap.getSourceFileName((int) addr + (i-4) * 4));
+                    }
+                } catch(Exception e) {}
+
+                // A remote target shall return an empty string for an unrecognized breakpoint or watchpoint packet type.
+                sendPacket(out, "OK");
+                continue;
+            }
+            else if (pkt.startsWith("z")) {
+                // TODO: Fix code duplication
+                String[] args = pkt.substring(1).split(",");
+                int type = Integer.parseInt(args[0]);
+                long addr = Long.parseUnsignedLong(args[1], 16);
+                int kind = Integer.parseInt(args[2]);
+                log("Remove breakpoint on " + addr);
+                debugger.removeBreakpoint((int) addr);
+
+                try {
+                    log("Breakpoint line " + debugSourceMap.getLineForPc((int) addr) + " " + debugSourceMap.getSourceFileName((int) addr));
+                } catch(Exception e) {}
+
+                // A remote target shall return an empty string for an unrecognized breakpoint or watchpoint packet type.
+                sendPacket(out, "OK");
+                continue;
+            }
+
+            switch (pkt) {
+                case "QStartNoAckMode":
+                    sendPacket(out, "OK");
+                    break;
+                case "qHostInfo":
+                    //sendPacket(out, "triple:x86_64-pc-linux-gnu;endian:little;ptrsize:8;");
+                    //sendPacket(out, "cputype:16777228;cpusubtype:3;ostype:darwin;vendor:apple;endian:little;ptrsize:8;hostname:hello;");
+                    sendPacket(out, "vendor:wamr;ostype:wasi;arch:wasm32;endian:little;ptrsize:4;");
+                    break;
+                case "qProcessInfo":
+                    sendPacket(out, "pid:1;parent-pid:1;vendor:wamr;ostype:wasi;arch:wasm32;triple:" + getTriple("wasm32-unknown-unknown-wasm") + ";endian:little;ptrsize:4;");
+                    //sendPacket(out, "pid:1;parent-pid:1;vendor:wamr;ostype:wasi;arch:wasm32;triple:7761736d33322d77616d722d776173692d7761736d;endian:little;ptrsize:4;");
+                    break;
+                case "qGetWorkingDir":
+                    sendPacket(out, "/tmp");
+                    break;
+                case "qQueryGDBServer":
+                    sendPacket(out, "PacketSize=4000");
+                    break;
+                case "qWasmCallStack:1": // Get the callstack for thread 1.
+                    Checkpoint lastCheckpoint = debugger.getCheckpoints().getLast();
+                    WOODDumpResponse state = getCurrentState();
+                    long currentPc = (long) state.getPc();
+                    String result = toHex(currentPc);
+                    for (int i = 0; i < state.getCallstack().size() - 1; i++) {
+                        result += toHex(0xdead); // TODO: Add other pc's in the callstack
+                    }
+                    log("Callstack size: " + state.getCallstack().size() + " pc = " + currentPc);
+                    sendPacket(out, result);
+
+                    try {
+                        log("Current line " + debugSourceMap.getLineForPc(state.getPc()) + " " + debugSourceMap.getSourceFileName(state.getPc()));
+                    } catch(Exception e) {}
+
+                    break;
+                case "qC": // Get thread id
+                    sendPacket(out, "QC 1");
+                    break;
+                case "qfThreadInfo":
+                    sendPacket(out, "m 1"); // Active threads start list
+                    break;
+                case "qsThreadInfo":
+                    sendPacket(out, "l"); // End of list
+                    break;
+                case "?":
+                    sendPacket(out, "S05"); // SIGTRAP
+                    break;
+                case "g":
+                    sendPacket(out, encodeRegs());
+                    break;
+                case "s":
+                    log("Received step command from lldb");
+                    debugger.stepInto();
+                    //sendPacket(out, "T05thread:1;pc:" + toHex(getCurrentState().getPc()) + ";");
+                    //sendPacket(out, "S05");
+                    sendPacket(out, "T05thread:1;name:warduino;thread-pcs:" + toHex(getCurrentState().getPc()) + ";00:" + toHex(getCurrentState().getPc()) + ";reason:trace");
+                    break;
+                case "c":
+                    // Pretend to run, then stop immediately
+                    debugger.run();
+                    //sendPacket(out, "S05");
+                    break;
+
+                default:
+                    System.out.println("Unknown packet: " + pkt);
+                    sendPacket(out, ""); // unsupported
+                    break;
+            }
+        }
+    }
+
+    private void log(String s) {
+        System.out.print("\u001b[36m");
+        System.out.print("[GDBSTUB] ");
+        System.out.println(s);
+        System.out.print("\u001b[0m");
+    }
+
+    private String recvPacket(InputStream in, OutputStream out) throws IOException {
+        int c;
+
+        // Wait for '$'
+        do {
+            c = in.read();
+            if (c == -1) return null;
+        } while (c != '$');
+
+        ByteArrayOutputStream payload = new ByteArrayOutputStream();
+
+        // Read until '#'
+        while ((c = in.read()) != '#') {
+            if (c == -1) return null;
+            payload.write(c);
+        }
+
+        // Read checksum
+        int c1 = in.read();
+        int c2 = in.read();
+        if (c1 == -1 || c2 == -1) return null;
+
+        int received = Integer.parseInt("" + (char)c1 + (char)c2, 16);
+        byte[] data = payload.toByteArray();
+        int computed = checksum(data);
+
+        if (received == computed) {
+            out.write('+'); // ACK
+            out.flush();
+            return new String(data);
+        } else {
+            out.write('-'); // NAK
+            out.flush();
+            return null;
+        }
+    }
+
+    private void sendPacket(OutputStream out, String payload) throws IOException {
+        byte[] data = payload.getBytes();
+        int sum = checksum(data);
+
+        String pkt = "$" + payload + "#" + String.format("%02x", sum);
+        out.write(pkt.getBytes());
+        out.flush();
+        System.out.println("-> " + pkt);
+    }
+
+    private int checksum(byte[] data) {
+        int sum = 0;
+        for (byte b : data) {
+            sum = (sum + (b & 0xFF)) & 0xFF;
+        }
+        return sum;
+    }
+
+    private String encodeRegs() {
+        StringBuilder sb = new StringBuilder();
+        for (int r : regs) {
+            sb.append(String.format("%08x", r));
+        }
+        return sb.toString();
+    }
+}

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -31,6 +31,7 @@ public class GdbStub {
 
         debugger.getBreakpointsListeners().add((pc) -> {
             try {
+                logger.info("Stopped at breakpoint {}", pc);
                 sendPacket(out, "S05");
             } catch (IOException e) {
                 throw new RuntimeException(e);
@@ -214,7 +215,7 @@ public class GdbStub {
                 debugger.addBreakpoint((int) addr);
 
                 try {
-                    logger.info("Breakpoint line {} {}", debugSourceMap.getLineForPc((int) addr), debugSourceMap.getSourceFileName((int) addr));
+                    logger.info("Add breakpoint at {}:{}", debugSourceMap.getSourceFileName((int) addr), debugSourceMap.getLineForPc((int) addr));
                 } catch(Exception _) {}
 
                 // A remote target shall return an empty string for an unrecognized breakpoint or watchpoint packet type.
@@ -231,8 +232,8 @@ public class GdbStub {
                 debugger.removeBreakpoint((int) addr);
 
                 try {
-                    logger.info("Breakpoint line {} {}", debugSourceMap.getLineForPc((int) addr), debugSourceMap.getSourceFileName((int) addr));
-                } catch(Exception e) {}
+                    logger.info("Remove breakpoint at {}:{}", debugSourceMap.getSourceFileName((int) addr), debugSourceMap.getLineForPc((int) addr));
+                } catch(Exception _) {}
 
                 // A remote target shall return an empty string for an unrecognized breakpoint or watchpoint packet type.
                 sendPacket(out, "OK");
@@ -274,8 +275,8 @@ public class GdbStub {
                     sendPacket(out, result);
 
                     try {
-                        logger.info("Current line {} {}", debugSourceMap.getLineForPc(state.getPc()), debugSourceMap.getSourceFileName(state.getPc()));
-                    } catch(Exception e) {}
+                        logger.info("At {}:{}", debugSourceMap.getSourceFileName(state.getPc()), debugSourceMap.getLineForPc(state.getPc()));
+                    } catch(Exception _) {}
 
                     break;
                 case "qC": // Get thread id
@@ -303,6 +304,7 @@ public class GdbStub {
                     sendStopPacket(out, "05");
                     break;
                 case "c":
+                    logger.info("Continue execution");
                     debugger.run();
                     break;
                 case "pause":

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -10,6 +10,8 @@ import java.net.ServerSocket;
 import java.net.Socket;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
 
 import static be.ugent.topl.mio.sourcemap.DwarfSourceMapKt.getDwarfSourcemap;
 
@@ -189,11 +191,12 @@ public class GdbStub {
                 int frameIdx =  Integer.parseInt(args[0]);
                 int localIdx =  Integer.parseInt(args[1]);
                 log("Reading local " + localIdx + " from frame " + frameIdx);
-                Frame frame = getCurrentState().getCallstack().get(getCurrentState().getCallstack().size() - frameIdx - 1);
+                Frame frame = getCallStack(getCurrentState()).get(frameIdx);
+                System.out.println(getCallStack(getCurrentState()));
                 System.out.println(frame);
                 System.out.println(getCurrentState().getStack());
                 int fp = frame.getFp();
-                long value = getCurrentState().getStack().get(fp + localIdx).getValue();
+                long value = getCurrentState().getStack().get(fp + localIdx + 1).getValue();
                 sendPacket(out, toHex(toWasmAddr(value))); // If a pointer on the stack is an address it will be clear it's a wasm memory pointer.
                 continue;
             }
@@ -401,5 +404,16 @@ public class GdbStub {
         StringBuilder sb = new StringBuilder();
         sb.append(String.format("%08x", getCurrentState().getPc()));
         return sb.toString();
+    }
+
+    private List<Frame> getCallStack(WOODDumpResponse state) {
+        List<Frame> callStack = new ArrayList<Frame>();
+        for (int i = state.getCallstack().size() - 1; i >= 0; i--) {
+            Frame f = state.getCallstack().get(i);
+            if (f.getType() == 0) {
+                callStack.add(state.getCallstack().get(i));
+            }
+        }
+        return callStack;
     }
 }

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -101,7 +101,7 @@ public class GdbStub {
         ServerSocket server = new ServerSocket(port);
         logger.info("Waiting for LLDB connection on port {}...", port);
         Socket sock = server.accept();
-        logger.info("LLDB connected!");
+        logger.info("LLDB connected! {}", sock.getInetAddress());
 
         InputStream in = sock.getInputStream();
         out = sock.getOutputStream();
@@ -164,7 +164,7 @@ public class GdbStub {
                 continue;
             }
             else if (pkt.startsWith("qSupported")) {
-                sendPacket(out, "qXfer:libraries:read+;vContSupported-;wasm+;");
+                sendPacket(out, "qXfer:libraries:read+;vContSupported-;wasm+;ReverseStep+;");
                 continue;
             }
             else if (pkt.startsWith("qXfer:libraries:read")) {
@@ -299,7 +299,7 @@ public class GdbStub {
                     debugger.stepInto();
                     sendStopPacket(out, "05");
                     break;
-                case "sb":
+                case "bs":
                     debugger.stepBack(1, () -> null);
                     sendStopPacket(out, "05");
                     break;

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -302,12 +302,16 @@ public class GdbStub {
                     debugger.stepInto();
                     //sendPacket(out, "T05thread:1;pc:" + toHex(getCurrentState().getPc()) + ";");
                     //sendPacket(out, "S05");
-                    sendPacket(out, "T05thread:1;name:warduino;thread-pcs:" + toHex(getCurrentState().getPc()) + ";00:" + toHex(getCurrentState().getPc()) + ";reason:trace");
+                    sendStopPacket(out, "05");
                     break;
                 case "c":
                     // Pretend to run, then stop immediately
                     debugger.run();
                     //sendPacket(out, "S05");
+                    break;
+                case "pause":
+                    debugger.pause();
+                    sendStopPacket(out, "02");
                     break;
                 case "D":
                     attached = false;
@@ -321,6 +325,10 @@ public class GdbStub {
                     break;
             }
         }
+    }
+
+    private void sendStopPacket(OutputStream out, String signal) throws IOException {
+        sendPacket(out, "T" + signal + "thread:1;name:warduino;thread-pcs:" + toHex(getCurrentState().getPc()) + ";00:" + toHex(getCurrentState().getPc()) + ";reason:trace");
     }
 
     private void log(String s) {
@@ -337,7 +345,11 @@ public class GdbStub {
         do {
             c = in.read();
             if (c == -1) return null;
-        } while (c != '$');
+        } while (c != '$' && c != 0x03); // 0x03 == pause request
+
+        if (c == 0x03) {
+            return "pause";
+        }
 
         ByteArrayOutputStream payload = new ByteArrayOutputStream();
 

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -4,6 +4,8 @@ import be.ugent.topl.mio.debugger.Debugger;
 import be.ugent.topl.mio.sourcemap.SourceMap;
 import be.ugent.topl.mio.woodstate.Frame;
 import be.ugent.topl.mio.woodstate.WOODDumpResponse;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import java.io.*;
 import java.net.ServerSocket;
@@ -19,12 +21,13 @@ public class GdbStub {
     private final Debugger debugger;
     private final String binaryLocation;
     private OutputStream out;
+    private final Logger logger = LoggerFactory.getLogger(GdbStub.class);
     private final SourceMap debugSourceMap; // Remove later, lldb doesn't need this.
 
     public GdbStub(Debugger debugger, String binaryLocation) {
         this.debugger = debugger;
         this.binaryLocation = binaryLocation;
-        debugSourceMap = getDwarfSourcemap(binaryLocation);
+        this.debugSourceMap = getDwarfSourcemap(binaryLocation);
 
         debugger.getBreakpointsListeners().add((pc) -> {
             try {
@@ -82,8 +85,6 @@ public class GdbStub {
         String hex = s.chars()
                 .mapToObj(c -> String.format("%02x", c))
                 .reduce("", String::concat);
-
-        System.out.println(hex);
         return hex;
     }
 
@@ -97,9 +98,9 @@ public class GdbStub {
         byte[] wasmData = Files.readAllBytes(Path.of(binaryLocation));
 
         ServerSocket server = new ServerSocket(port);
-        System.out.printf("Waiting for GDB on port %d...", port);
+        logger.info("Waiting for LLDB connection on port {}...", port);
         Socket sock = server.accept();
-        System.out.println("GDB connected!");
+        logger.info("LLDB connected!");
 
         InputStream in = sock.getInputStream();
         out = sock.getOutputStream();
@@ -109,10 +110,10 @@ public class GdbStub {
         while (attached) {
             String pkt = recvPacket(in, out);
             if (pkt == null) {
-                System.out.println("GDB closed");
+                logger.info("Connection closed");
                 break;
             }
-            System.out.println("<- " + pkt);
+            logger.trace("<- {}", pkt);
 
             if (pkt.startsWith("m")) {
                 pkt = pkt.substring(1);
@@ -121,7 +122,7 @@ public class GdbStub {
                 long addrType = getAddrType(pos);
                 pos = stripAddrType(pos);
                 long len = Long.parseUnsignedLong(memArgs[1], 16);
-                log("Read memory " + len + " bytes from " + pos + " with addr type = " + addrType);
+                logger.info("Read memory {} bytes from {} with addr type = {}", len, pos, addrType);
 
                 // TODO: Hack to temporarily prevent lldb from using breakpoints when stepping
                 //  https://github.com/llvm/llvm-project/issues/189960
@@ -132,7 +133,7 @@ public class GdbStub {
 
                 byte[] memory = wasmData;
                 if (addrType == 1) {
-                    log("Reading from wasm linear memory");
+                    logger.info("Reading from wasm linear memory");
                     memory = getCurrentState().getMemory().getBytes();
                 }
                 else {
@@ -141,7 +142,7 @@ public class GdbStub {
 
                 // The reply may contain fewer addressable memory units than requested if the server was reading from a trace frame memory and was able to read only part of the region of memory.
                 if (pos >= memory.length || pos < 0) {
-                    System.out.println("Pos " + pos + " out of bounds for length " + memory.length);
+                    logger.warn("Pos {} out of bounds for length {}", pos, memory.length);
                     sendPacket(out, "E01");
                     continue;
                 }
@@ -152,17 +153,13 @@ public class GdbStub {
                     // also think about little vs big endian
                     int index = (int) pos + i;
                     if (index >= memory.length) {
-                        System.out.println("Stop reading, out of bounds");
+                        logger.info("Stop reading, out of bounds");
                         break;
                     }
                     int b = memory[index];
                     result.append(String.format("%02x", b & 0xFF));
-                    //result.append("00");
                 }
                 sendPacket(out, result.toString());
-
-                // If memory invalid send E01
-                //sendPacket(out, "E01");
                 continue;
             }
             else if (pkt.startsWith("qSupported")) {
@@ -190,11 +187,11 @@ public class GdbStub {
                 String[] args = pkt.substring("qWasmLocal:".length()).split(";");
                 int frameIdx =  Integer.parseInt(args[0]);
                 int localIdx =  Integer.parseInt(args[1]);
-                log("Reading local " + localIdx + " from frame " + frameIdx);
+                logger.info("Reading local {} from frame {}", localIdx, frameIdx);
                 Frame frame = getCallStack(getCurrentState()).get(frameIdx);
-                System.out.println(getCallStack(getCurrentState()));
-                System.out.println(frame);
-                System.out.println(getCurrentState().getStack());
+                logger.trace("{}", getCallStack(getCurrentState()));
+                logger.trace("{}", frame);
+                logger.trace("{}", getCurrentState().getStack());
                 int fp = frame.getFp();
                 long value = getCurrentState().getStack().get(fp + localIdx + 1).getValue();
                 sendPacket(out, toHex(toWasmAddr(value))); // If a pointer on the stack is an address it will be clear it's a wasm memory pointer.
@@ -213,14 +210,12 @@ public class GdbStub {
                 int type = Integer.parseInt(args[0]);
                 long addr = Long.parseUnsignedLong(args[1], 16);
                 int kind = Integer.parseInt(args[2]);
-                log("Add breakpoint on " + addr);
+                logger.info("Add breakpoint on {}", addr);
                 debugger.addBreakpoint((int) addr);
 
                 try {
-                    for (int i = 0; i < 8; i++) {
-                        log("Breakpoint line " + debugSourceMap.getLineForPc((int) addr + (i-4) * 4) + " " + debugSourceMap.getSourceFileName((int) addr + (i-4) * 4));
-                    }
-                } catch(Exception e) {}
+                    logger.info("Breakpoint line {} {}", debugSourceMap.getLineForPc((int) addr), debugSourceMap.getSourceFileName((int) addr));
+                } catch(Exception _) {}
 
                 // A remote target shall return an empty string for an unrecognized breakpoint or watchpoint packet type.
                 sendPacket(out, "OK");
@@ -232,11 +227,11 @@ public class GdbStub {
                 int type = Integer.parseInt(args[0]);
                 long addr = Long.parseUnsignedLong(args[1], 16);
                 int kind = Integer.parseInt(args[2]);
-                log("Remove breakpoint on " + addr);
+                logger.info("Remove breakpoint on {}", addr);
                 debugger.removeBreakpoint((int) addr);
 
                 try {
-                    log("Breakpoint line " + debugSourceMap.getLineForPc((int) addr) + " " + debugSourceMap.getSourceFileName((int) addr));
+                    logger.info("Breakpoint line {} {}", debugSourceMap.getLineForPc((int) addr), debugSourceMap.getSourceFileName((int) addr));
                 } catch(Exception e) {}
 
                 // A remote target shall return an empty string for an unrecognized breakpoint or watchpoint packet type.
@@ -254,8 +249,6 @@ public class GdbStub {
                     sendPacket(out, "OK");
                     break;*/
                 case "qHostInfo":
-                    //sendPacket(out, "triple:x86_64-pc-linux-gnu;endian:little;ptrsize:8;");
-                    //sendPacket(out, "cputype:16777228;cpusubtype:3;ostype:darwin;vendor:apple;endian:little;ptrsize:8;hostname:hello;");
                     sendPacket(out, "vendor:wamr;ostype:wasi;arch:wasm32;endian:little;ptrsize:4;");
                     break;
                 case "qProcessInfo":
@@ -281,7 +274,7 @@ public class GdbStub {
                     sendPacket(out, result);
 
                     try {
-                        log("Current line " + debugSourceMap.getLineForPc(state.getPc()) + " " + debugSourceMap.getSourceFileName(state.getPc()));
+                        logger.info("Current line {} {}", debugSourceMap.getLineForPc(state.getPc()), debugSourceMap.getSourceFileName(state.getPc()));
                     } catch(Exception e) {}
 
                     break;
@@ -301,7 +294,7 @@ public class GdbStub {
                     sendPacket(out, encodeRegs());
                     break;
                 case "s":
-                    log("Received step command from lldb");
+                    logger.info("Received step command from lldb");
                     debugger.stepInto();
                     sendStopPacket(out, "05");
                     break;
@@ -318,12 +311,12 @@ public class GdbStub {
                     break;
                 case "D":
                     attached = false;
-                    log("Detach from target");
+                    logger.info("Detach from target");
                     debugger.close();
                     sendPacket(out, "OK");
                     break;
                 default:
-                    System.out.println("Unknown packet: " + pkt);
+                    logger.warn("Unknown packet: {}", pkt);
                     sendPacket(out, "");
                     break;
             }
@@ -332,13 +325,6 @@ public class GdbStub {
 
     private void sendStopPacket(OutputStream out, String signal) throws IOException {
         sendPacket(out, "T" + signal + "thread:1;name:warduino;thread-pcs:" + toHex(getCurrentState().getPc()) + ";00:" + toHex(getCurrentState().getPc()) + ";reason:trace");
-    }
-
-    private void log(String s) {
-        System.out.print("\u001b[36m");
-        System.out.print("[GDBSTUB] ");
-        System.out.println(s);
-        System.out.print("\u001b[0m");
     }
 
     private String recvPacket(InputStream in, OutputStream out) throws IOException {
@@ -389,7 +375,7 @@ public class GdbStub {
         String pkt = "$" + payload + "#" + String.format("%02x", sum);
         out.write(pkt.getBytes());
         out.flush();
-        System.out.println("-> " + pkt);
+        logger.trace("-> {}", pkt);
     }
 
     private int checksum(byte[] data) {

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -110,7 +110,9 @@ public class GdbStub {
         InputStream in = sock.getInputStream();
         out = sock.getOutputStream();
 
-        while (true) {
+        boolean attached = true;
+
+        while (attached) {
             String pkt = recvPacket(in, out);
             if (pkt == null) {
                 System.out.println("GDB closed");
@@ -246,6 +248,11 @@ public class GdbStub {
                 sendPacket(out, "OK");
                 continue;
             }
+            else if (pkt.startsWith("stackInfo")) {
+                //debugger.stepBack(1, wasmData);
+                sendPacket(out, getCurrentState().getStack().toString());
+                continue;
+            }
 
             switch (pkt) {
                 /*case "QStartNoAckMode":
@@ -310,7 +317,12 @@ public class GdbStub {
                     debugger.run();
                     //sendPacket(out, "S05");
                     break;
-
+                case "D":
+                    attached = false;
+                    log("Detach from target");
+                    debugger.close();
+                    sendPacket(out, "OK");
+                    break;
                 default:
                     System.out.println("Unknown packet: " + pkt);
                     sendPacket(out, ""); // unsupported

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -95,21 +95,30 @@ public class GdbStub {
     }
 
     public void start(int port) throws IOException {
+        start(port, false);
+    }
+
+    public void start(int port, boolean closeOnDetach) throws IOException {
         debugger.pause();
 
         byte[] wasmData = Files.readAllBytes(Path.of(binaryLocation));
 
         ServerSocket server = new ServerSocket(port);
-        logger.info("Waiting for LLDB connection on port {}...", port);
-        Socket sock = server.accept();
-        logger.info("LLDB connected! {}", sock.getInetAddress());
+        Socket sock;
+        InputStream in = null;
+        boolean attached = false;
 
-        InputStream in = sock.getInputStream();
-        out = sock.getOutputStream();
+        do {
+            if (!attached) {
+                logger.info("Waiting for LLDB connection on port {}...", port);
+                sock = server.accept();
+                logger.info("LLDB connected! {}", sock.getInetAddress());
 
-        boolean attached = true;
+                in = sock.getInputStream();
+                out = sock.getOutputStream();
+                attached = true;
+            }
 
-        while (attached) {
             String pkt = recvPacket(in, out);
             if (pkt == null) {
                 logger.info("Connection closed");
@@ -337,7 +346,6 @@ public class GdbStub {
                 case "D":
                     attached = false;
                     logger.info("Detach from target");
-                    debugger.close();
                     sendPacket(out, "OK");
                     break;
                 default:
@@ -345,7 +353,8 @@ public class GdbStub {
                     sendPacket(out, "");
                     break;
             }
-        }
+        } while(!closeOnDetach || attached);
+        debugger.close();
     }
 
     private void stepBack(int n) throws IOException {

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -36,19 +36,6 @@ public class GdbStub {
         });
     }
 
-    private static final char[] HEX = "0123456789abcdef".toCharArray();
-    private String toHex(byte[] data, int offset, int length) {
-        StringBuilder sb = new StringBuilder(length * 2);
-
-        for (int i = 0; i < length; i++) {
-            int b = data[offset + i] & 0xFF;
-            sb.append(HEX[b >>> 4]);
-            sb.append(HEX[b & 0x0F]);
-        }
-
-        return sb.toString();
-    }
-
     private String toHex(long data, int maxLen, boolean bigEndian) {
         StringBuilder result = new StringBuilder();
         for (int i = 0; i < maxLen; i++) {
@@ -79,10 +66,9 @@ public class GdbStub {
     }
 
     private String getTriple(String s) {
-        String hex = s.chars()
+        return s.chars()
                 .mapToObj(c -> String.format("%02x", c))
                 .reduce("", String::concat);
-        return hex;
     }
 
     public WOODDumpResponse getCurrentState() {
@@ -141,9 +127,6 @@ public class GdbStub {
                 if (addrType == 1) {
                     logger.info("Reading from wasm linear memory");
                     memory = getCurrentState().getMemory().getBytes();
-                }
-                else {
-                    //pos -= codeSection.offset;
                 }
 
                 // The reply may contain fewer addressable memory units than requested if the server was reading from a trace frame memory and was able to read only part of the region of memory.
@@ -266,7 +249,6 @@ public class GdbStub {
                     break;
                 case "qProcessInfo":
                     sendPacket(out, "pid:1;parent-pid:1;vendor:wamr;ostype:wasi;arch:wasm32;triple:" + getTriple("wasm32-unknown-unknown-wasm") + ";endian:little;ptrsize:4;");
-                    //sendPacket(out, "pid:1;parent-pid:1;vendor:wamr;ostype:wasi;arch:wasm32;triple:7761736d33322d77616d722d776173692d7761736d;endian:little;ptrsize:4;");
                     break;
                 case "qGetWorkingDir":
                     sendPacket(out, "/tmp");
@@ -276,15 +258,15 @@ public class GdbStub {
                     break;
                 case "qWasmCallStack:1": // Get the callstack for thread 1.
                     WOODDumpResponse state = getCurrentState();
-                    String result = toHex(state.getPc());
+                    StringBuilder result = new StringBuilder(toHex(state.getPc()));
                     for (int i = state.getCallstack().size() - 1; i >= 0; i--) {
                         // Only functions are real callstack elements:
                         Frame f = state.getCallstack().get(i);
                         if (f.getType() == 0) {
-                            result += toHex(f.getRa());
+                            result.append(toHex(f.getRa()));
                         }
                     }
-                    sendPacket(out, result);
+                    sendPacket(out, result.toString());
 
                     break;
                 case "qC": // Get thread id
@@ -300,7 +282,7 @@ public class GdbStub {
                     sendPacket(out, "S05"); // SIGTRAP
                     break;
                 case "g":
-                    sendPacket(out, encodeRegs());
+                    sendPacket(out, String.format("%08x", getCurrentState().getPc()));
                     break;
                 case "s":
                     logger.info("Received step command from lldb");
@@ -411,12 +393,6 @@ public class GdbStub {
             sum = (sum + (b & 0xFF)) & 0xFF;
         }
         return sum;
-    }
-
-    private String encodeRegs() {
-        StringBuilder sb = new StringBuilder();
-        sb.append(String.format("%08x", getCurrentState().getPc()));
-        return sb.toString();
     }
 
     private List<Frame> getCallStack(WOODDumpResponse state) {

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -302,6 +302,10 @@ public class GdbStub {
                     debugger.stepInto();
                     sendStopPacket(out, "05");
                     break;
+                case "sb":
+                    debugger.stepBack(1, () -> null);
+                    sendStopPacket(out, "05");
+                    break;
                 case "c":
                     debugger.run();
                     break;

--- a/src/main/java/be/ugent/topl/mio/GdbStub.java
+++ b/src/main/java/be/ugent/topl/mio/GdbStub.java
@@ -300,14 +300,10 @@ public class GdbStub {
                 case "s":
                     log("Received step command from lldb");
                     debugger.stepInto();
-                    //sendPacket(out, "T05thread:1;pc:" + toHex(getCurrentState().getPc()) + ";");
-                    //sendPacket(out, "S05");
                     sendStopPacket(out, "05");
                     break;
                 case "c":
-                    // Pretend to run, then stop immediately
                     debugger.run();
-                    //sendPacket(out, "S05");
                     break;
                 case "pause":
                     debugger.pause();
@@ -321,7 +317,7 @@ public class GdbStub {
                     break;
                 default:
                     System.out.println("Unknown packet: " + pkt);
-                    sendPacket(out, ""); // unsupported
+                    sendPacket(out, "");
                     break;
             }
         }

--- a/src/main/kotlin/be/ugent/topl/mio/Main.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/Main.kt
@@ -52,6 +52,19 @@ fun main(args: Array<String>) {
     }
     expectNArguments(args, 1)
     val config = DebuggerConfig()
+
+    if (args[0].startsWith("-p=") || args[0].startsWith("--port=")) {
+        expectNArguments(args, 2)
+        val wasmFilename = args[1]
+        val port = args[0].split("=")[1].toInt()
+        val debugger = Debugger(ProcessConnection(config.wdcliPath, wasmFilename, "--no-socket", "--paused"))
+        debugger.pause()
+        debugger.setSnapshotPolicy(Debugger.SnapshotPolicy.Checkpointing())
+        val stub = GdbStub(debugger, wasmFilename)
+        stub.start(port)
+        return
+    }
+
     when (args[0]) {
         "debug" -> {
             expectNArguments(args, 2)
@@ -150,15 +163,6 @@ fun main(args: Array<String>) {
                 config.fqbn,
                 config.port!!
             )
-        }
-        "debug-server" -> {
-            expectNArguments(args, 2)
-            val wasmFilename = args[1]
-            val debugger = Debugger(ProcessConnection(config.wdcliPath, wasmFilename, "--no-socket", "--paused"))
-            debugger.pause()
-            debugger.setSnapshotPolicy(Debugger.SnapshotPolicy.Checkpointing())
-            val stub = GdbStub(debugger, wasmFilename)
-            stub.start()
         }
         else -> {
             println("Invalid option \"${args[0]}\"!")

--- a/src/main/kotlin/be/ugent/topl/mio/Main.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/Main.kt
@@ -151,6 +151,17 @@ fun main(args: Array<String>) {
                 config.port!!
             )
         }
+        "gdbstub" -> {
+            //val wasmFilename = "main.wasm"
+            val wasmFilename = "test-dbg.wasm"
+            val debugger = Debugger(ProcessConnection(config.wdcliPath, wasmFilename, "--no-socket", "--paused")) {
+                println("Hit breakpoint!")
+            }
+            debugger.pause()
+            debugger.setSnapshotPolicy(Debugger.SnapshotPolicy.Checkpointing())
+            val stub = GdbStub(debugger, wasmFilename)
+            stub.start()
+        }
         else -> {
             println("Invalid option \"${args[0]}\"!")
             exitProcess(1)

--- a/src/main/kotlin/be/ugent/topl/mio/Main.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/Main.kt
@@ -153,10 +153,8 @@ fun main(args: Array<String>) {
         }
         "gdbstub" -> {
             //val wasmFilename = "main.wasm"
-            val wasmFilename = "test-dbg.wasm"
-            val debugger = Debugger(ProcessConnection(config.wdcliPath, wasmFilename, "--no-socket", "--paused")) {
-                println("Hit breakpoint!")
-            }
+            val wasmFilename = "tmp/test-dbg.wasm"
+            val debugger = Debugger(ProcessConnection(config.wdcliPath, wasmFilename, "--no-socket", "--paused"))
             debugger.pause()
             debugger.setSnapshotPolicy(Debugger.SnapshotPolicy.Checkpointing())
             val stub = GdbStub(debugger, wasmFilename)

--- a/src/main/kotlin/be/ugent/topl/mio/Main.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/Main.kt
@@ -3,14 +3,14 @@ package be.ugent.topl.mio
 import be.ugent.topl.mio.connections.ProcessConnection
 import be.ugent.topl.mio.connections.SerialConnection
 import be.ugent.topl.mio.debugger.Debugger
-import com.formdev.flatlaf.FlatDarkLaf
-import com.formdev.flatlaf.FlatIntelliJLaf
 import be.ugent.topl.mio.sourcemap.AsSourceMapping
 import be.ugent.topl.mio.sourcemap.compileAndFlash
 import be.ugent.topl.mio.sourcemap.compileWat
 import be.ugent.topl.mio.sourcemap.getDwarfSourcemap
 import be.ugent.topl.mio.ui.InteractiveDebugger
 import be.ugent.topl.mio.ui.StartScreen
+import com.formdev.flatlaf.FlatDarkLaf
+import com.formdev.flatlaf.FlatIntelliJLaf
 import com.formdev.flatlaf.util.SystemInfo
 import java.io.File
 import java.io.FileNotFoundException
@@ -57,7 +57,8 @@ fun main(args: Array<String>) {
         expectNArguments(args, 2)
         val wasmFilename = args[1]
         val port = args[0].split("=")[1].toInt()
-        val debugger = Debugger(ProcessConnection(config.wdcliPath, wasmFilename, "--no-socket", "--paused"))
+        val connection = if(config.useEmulator) ProcessConnection(config.wdcliPath, wasmFilename, "--no-socket", "--paused") else SerialConnection(config.port!!)
+        val debugger = Debugger(connection)
         debugger.pause()
         debugger.setSnapshotPolicy(Debugger.SnapshotPolicy.Checkpointing())
         val stub = GdbStub(debugger, wasmFilename)

--- a/src/main/kotlin/be/ugent/topl/mio/Main.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/Main.kt
@@ -151,9 +151,9 @@ fun main(args: Array<String>) {
                 config.port!!
             )
         }
-        "gdbstub" -> {
-            //val wasmFilename = "main.wasm"
-            val wasmFilename = "tmp/test-dbg.wasm"
+        "debug-server" -> {
+            expectNArguments(args, 2)
+            val wasmFilename = args[1]
             val debugger = Debugger(ProcessConnection(config.wdcliPath, wasmFilename, "--no-socket", "--paused"))
             debugger.pause()
             debugger.setSnapshotPolicy(Debugger.SnapshotPolicy.Checkpointing())

--- a/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
@@ -14,8 +14,8 @@ import java.util.*
 import kotlin.concurrent.thread
 import kotlin.streams.toList
 
-open class Debugger(private val connection: Connection, start: Boolean = true, private val onHitBreakpoint: (Int) -> Unit = {}) : Closeable, AutoCloseable {
-    private val requestQueue: Queue<Int> = LinkedList()
+open class Debugger(private val connection: Connection, start: Boolean = true, onHitBreakpoint: (Int) -> Unit = {}) : Closeable, AutoCloseable {
+    var breakpointsListeners:  MutableList<(Int) -> Unit> = mutableListOf(onHitBreakpoint)
     var printListener: ((String) -> Unit)? = null
     private val messageQueue = MessageQueue {
         for (msg in it) {
@@ -39,6 +39,7 @@ open class Debugger(private val connection: Connection, start: Boolean = true, p
             connection.read(readBuffer)
             messageQueue.push(String(readBuffer), true)
 
+            //println(String(readBuffer))
             while (true) {
                 val checkpointMessage = messageQueue.search {
                     val match = Regex("CHECKPOINT (.*)").matchEntire(it.trimEnd('\r')) ?: throw Exception()
@@ -97,7 +98,9 @@ open class Debugger(private val connection: Connection, start: Boolean = true, p
                      * incoming messages, so the request would never be completed.
                      */
                     thread {
-                        onHitBreakpoint(searchAtResult.second)
+                        for (breakpointListener in breakpointsListeners) {
+                            breakpointListener(searchAtResult.second)
+                        }
                     }
                 }
             }
@@ -175,7 +178,6 @@ open class Debugger(private val connection: Connection, start: Boolean = true, p
 
     private fun send(code: Int, payload: String = "") {
         val str = String.format("%02d$payload\n", code)
-        requestQueue.add(code)
         print("Sending $str")
         val write = str.toByteArray()
         connection.write(write)

--- a/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
@@ -223,14 +223,14 @@ open class Debugger(private val connection: Connection, start: Boolean = true, o
         return checkpoints.size > 1
     }
 
-    fun stepBackUntil(binaryInfo: WasmInfo, cond: (WOODDumpResponse) -> Boolean) {
-        stepBack(1, binaryInfo) {}
+    fun stepBackUntil(cond: (WOODDumpResponse) -> Boolean) {
+        stepBack()
         while (!cond(checkpoints.last()!!.snapshot)) {
             if (!canStepBack()) {
                 System.err.println("WARNING: Can't go back further!")
                 return
             }
-            stepBack(1, binaryInfo)
+            stepBack()
         }
     }
 
@@ -263,7 +263,7 @@ open class Debugger(private val connection: Connection, start: Boolean = true, o
         println("count = ${checkpoints.size}")
     }
 
-    open fun stepBack(n: Int, binaryInfo: WasmInfo, stepDone: () -> Unit = {}) {
+    open fun stepBack(n: Int = 1, stepDone: () -> Unit = {}) {
         if (n == 0) {
             return
         }
@@ -271,7 +271,7 @@ open class Debugger(private val connection: Connection, start: Boolean = true, o
         val currentState = checkpoints.removeLast() // Remove current state, we don't need to restore this, we are already in this state.
         val nSnapshots = checkpoints.subList(checkpoints.size - n, checkpoints.size).toList()
         for (checkpoint in nSnapshots.reversed()) {
-            if (checkpoint != null && (checkpoint.snapshot.pc in binaryInfo.after_primitive_calls || nSnapshots.first() == checkpoint)) {
+            if (checkpoint != null && (checkpoint.fidx_called != null || nSnapshots.first() == checkpoint)) {
             //if (snapshot != null) {
                 println("Snapshot to ${checkpoint.snapshot.pc}")
                 val s = checkpoint.snapshot

--- a/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/debugger/Debugger.kt
@@ -219,8 +219,8 @@ open class Debugger(private val connection: Connection, start: Boolean = true, o
         }
     }
 
-    private fun canStepBack(): Boolean {
-        return checkpoints.size > 1
+    fun canStepBack(n: Int = 1): Boolean {
+        return checkpoints.size > n
     }
 
     fun stepBackUntil(cond: (WOODDumpResponse) -> Boolean) {

--- a/src/main/kotlin/be/ugent/topl/mio/debugger/MultiverseDebugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/debugger/MultiverseDebugger.kt
@@ -1,7 +1,6 @@
 package be.ugent.topl.mio.debugger
 
 import WasmBinary
-import WasmInfo
 import be.ugent.topl.mio.concolic.analyse
 import be.ugent.topl.mio.concolic.processPaths
 import be.ugent.topl.mio.connections.Connection
@@ -202,12 +201,12 @@ class MultiverseDebugger(
         }*/
     }
 
-    override fun stepBack(n: Int, binaryInfo: WasmInfo, stepDone: () -> Unit) {
+    override fun stepBack(n: Int, stepDone: () -> Unit) {
         var destinationNode = graph.currentNode
         for (i in 0 ..< n) {
             destinationNode = destinationNode.parent!!
         }
-        super.stepBack(n, binaryInfo, stepDone)
+        super.stepBack(n, stepDone)
 
         graph.currentNode = destinationNode
         graphUpdated()

--- a/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/ui/InteractiveDebugger.kt
@@ -136,7 +136,7 @@ class InteractiveDebugger(
         stepBackButton.addActionListener {
             println("Step back")
             //debugger.stepBack()
-            debugger.stepBack(1, binaryInfo) {}
+            debugger.stepBack()
             updateStepBackButton()
             updatePcLabel()
         }
@@ -193,7 +193,7 @@ class InteractiveDebugger(
             } catch(re: RuntimeException) {
                 System.err.println("WARNING: " + re.message)
             }
-            debugger.stepBackUntil(binaryInfo) {
+            debugger.stepBackUntil {
                 try {
                     sourceMapping.getLineForPc(it.pc!!) != startLine
                 } catch(re: RuntimeException) {
@@ -541,7 +541,7 @@ class MultiversePanel(private val multiverseDebugger: MultiverseDebugger, config
                 val totalLength = backwardsLength + forwardsLength
                 val backwardPath = graphPanel.selectedPath!!.first.toMutableList()
                 var finishedSteps = 0
-                multiverseDebugger.stepBack(backwardPath.size, multiverseDebugger.wasmBinary.metadata) {
+                multiverseDebugger.stepBack(backwardPath.size) {
                     graphPanel.completedPath.add(backwardPath.removeFirst())
                     graphPanel.repaint()
                     val remaining = forwardsLength + backwardPath.size

--- a/src/main/kotlin/be/ugent/topl/mio/woodstate/WOODState.kt
+++ b/src/main/kotlin/be/ugent/topl/mio/woodstate/WOODState.kt
@@ -156,6 +156,7 @@ data class Checkpoint(
     val instructions_executed: Int,
     val fidx_called: Int?,
     val args: List<Int>?,
+    val returns: List<Int>?,
     val snapshot: WOODDumpResponse
 )
 

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,0 +1,22 @@
+<configuration>
+    <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+        <encoder>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+        </encoder>
+        <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
+            <level>DEBUG</level>
+        </filter>
+    </appender>
+
+    <appender name="FILE" class="ch.qos.logback.core.FileAppender">
+        <file>mio.log</file>
+        <encoder>
+            <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
+        </encoder>
+    </appender>
+
+    <root level="TRACE">
+        <appender-ref ref="STDOUT" />
+        <appender-ref ref="FILE" />
+    </root>
+</configuration>

--- a/src/main/resources/logback.xml
+++ b/src/main/resources/logback.xml
@@ -1,7 +1,7 @@
 <configuration>
     <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
         <encoder>
-            <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger{36} - %msg%n</pattern>
+            <pattern>%d{HH:mm:ss.SSS} [%thread] %highlight(%-5level) %logger{36} - %msg%n</pattern>
         </encoder>
         <filter class="ch.qos.logback.classic.filter.ThresholdFilter">
             <level>DEBUG</level>
@@ -10,6 +10,7 @@
 
     <appender name="FILE" class="ch.qos.logback.core.FileAppender">
         <file>mio.log</file>
+        <append>false</append>
         <encoder>
             <pattern>%-4relative [%thread] %-5level %logger{35} - %msg%n</pattern>
         </encoder>


### PR DESCRIPTION
Started working on this on March 29th. Implements a basic gdb stub server allowing LLDB to connect to MIO and debug programs with full source level information. Supports step back, although this feature currently requires a custom version of LLDB. The changes needed in LLDB are currently being upstreamed. Mocking and sliding is currently not part of this, this would require a custom LLDB plugin since LLDB has not multiverse debugging capabilities. Mocking should not be very hard since custom extensions can be added to the gdb stub and LLDB can send them with `process plugin packet send`.